### PR TITLE
Add spec-prod to deploy workflow; add PR validation workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,11 +11,6 @@ jobs:
 
     permissions:
       contents: write
-      pages: write
-      id-token: write
-
-    environment:
-      name: github-pages
 
     steps:
       # Checkout repository
@@ -43,13 +38,36 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Add generated index.html
+      
+      - name: Run spec-prod
+        uses: w3c/spec-prod@v2
 
-      # Upload artifacts
-      - name: Upload artifacts
-        uses: actions/upload-pages-artifact@v3
+  upload:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Download spec-prod artifact
+        uses: actions/download-artifact@v4
         with:
-          path: ./
+          name: spec-prod-result
+          path: _site
 
-      # Deploy to GitHub Pages
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: upload
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v4

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -1,0 +1,27 @@
+name: PR Validation
+
+on: pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Node dependencies and run script
+        run: |
+          npm install
+
+      - name: Run Node script
+        run: |
+          node matf.js
+
+      - name: Run spec-prod
+        uses: w3c/spec-prod@v2


### PR DESCRIPTION
This updates the deploy workflow to also run the generated `index.html` through the spec-prod action, so that the already-processed document is served from GitHub Pages rather than needing to run ReSpec client-side.

- [Spec produced by updated workflow](https://kfranqueiro.github.io/matf/)
- [Successful deploy workflow run](https://github.com/kfranqueiro/matf/actions/runs/14781762448)

This also adds a new workflow for running spec-prod's validation pass on PRs. Example runs:

- [Failure](https://github.com/kfranqueiro/matf/actions/runs/14911261827/job/41885971251) (failed by inserting `<dl><p>...</p></dl>` which is invalid)
- [Success](https://github.com/kfranqueiro/matf/actions/runs/14911425153/job/41886510355)